### PR TITLE
Don't override <expr> mappings

### DIFF
--- a/plugin/hyperstyle.vim
+++ b/plugin/hyperstyle.vim
@@ -28,12 +28,21 @@ function! s:enable(semi)
 endfunction
 
 function! s:map_key(key, binding)
-  let oldmap = maparg(a:key, 'i')
+  let oldmap_dict = maparg(a:key, 'i', 0, 1)
+  let oldmap = get(oldmap_dict, 'rhs', '')
+
+  " If there's already a mappig with <expr> then we currently *do not*
+  " override it. Future work could create our own expression mapping
+  " that evals the rhs of the original mapping, but its simpler to just
+  " not interfere.
+  let expr = get(oldmap_dict, 'expr', 0)
 
   if oldmap =~# "<Plug>(".a:binding.")"
     " already mapped. maybe the user was playing with `set ft`
   elseif oldmap != ""
-    exe "imap <silent> ".a:key." ".oldmap."<Plug>(".a:binding.")"
+    if !expr
+      exe "imap <silent> ".a:key." ".oldmap."<Plug>(".a:binding.")"
+    endif
   else
     exe "imap <silent> <buffer> ".a:key." ".a:key."<Plug>(".a:binding.")"
   endif

--- a/plugin/hyperstyle.vim
+++ b/plugin/hyperstyle.vim
@@ -31,7 +31,7 @@ function! s:map_key(key, binding)
   let oldmap_dict = maparg(a:key, 'i', 0, 1)
   let oldmap = get(oldmap_dict, 'rhs', '')
 
-  " If there's already a mappig with <expr> then we currently *do not*
+  " If there's already a mapping with <expr> then we currently *do not*
   " override it. Future work could create our own expression mapping
   " that evals the rhs of the original mapping, but its simpler to just
   " not interfere.


### PR DESCRIPTION
Refs rstacruz/vim-hyperstyle#8. Probably also rstacruz/vim-hyperstyle#1

As mentioned in the comments, it may be possible to create our own `<expr>` mapping in this case that evals the right hand side of the original mapping, but I'm not sure how the two would interact—for example, YCM creates a mapping that manipulates the popup menu *if it's open*.